### PR TITLE
Bump utils/yip to 0.6.1

### DIFF
--- a/multi-arch/packages/yip/definition.yaml
+++ b/multi-arch/packages/yip/definition.yaml
@@ -1,6 +1,6 @@
 category: "utils"
 name: "yip"
-version: "0.6"
+version: "0.6.3"
 labels:
   github.repo: "yip"
   github.owner: "mudler"


### PR DESCRIPTION
git-prune: not as tasty as git-cherry, but much better for you