### PR TITLE
Bump utils/upterm to 0.6.5

### DIFF
--- a/multi-arch/packages/upterm/definition.yaml
+++ b/multi-arch/packages/upterm/definition.yaml
@@ -1,6 +1,6 @@
 name: upterm
 category: utils
-version: "0.6.3"
+version: "0.6.5"
 labels:
   github.repo: "upterm"
   github.owner: "owenthereal"


### PR DESCRIPTION
Because they use a strongly typed language.