### PR TITLE
Bump utils/packer to 1.7.2

### DIFF
--- a/amd64/packages/packer/definition.yaml
+++ b/amd64/packages/packer/definition.yaml
@@ -1,6 +1,6 @@
 category: "utils"
 name: "packer"
-version: "1.7.1"
+version: "1.7.2"
 license: "MPL-2.0"
 description: "Packer is a tool for creating identical machine images for multiple platforms from a single source configuration"
 labels:


### PR DESCRIPTION
git-clone has nothing to do with reproduction. So stop that.