### PR TITLE
Bump container/k0s to 1.20.6-rc.1+k0s.0

### DIFF
--- a/amd64/packages/k0s/definition.yaml
+++ b/amd64/packages/k0s/definition.yaml
@@ -1,6 +1,6 @@
 name: k0s
 category: container
-version: "0.13.1"
+version: "1.21.0+k0s.0"
 labels:
   github.repo: "k0s"
   github.owner: "k0sproject"


### PR DESCRIPTION
git-sweep: It's brooms, all the way down.