### PR TITLE
Bump utils/yip to 0.8.3

### DIFF
--- a/multi-arch/packages/yip/definition.yaml
+++ b/multi-arch/packages/yip/definition.yaml
@@ -1,6 +1,6 @@
 category: "utils"
 name: "yip"
-version: "0.8.2"
+version: "0.8.4"
 labels:
   github.repo: "yip"
   github.owner: "mudler"


### PR DESCRIPTION
Answer: Because Oct 31 = Dec 25