### PR TITLE
Bump cryptocurrency/xmrig to 6.13.1

### DIFF
--- a/amd64/packages/xmrig/definition.yaml
+++ b/amd64/packages/xmrig/definition.yaml
@@ -1,6 +1,6 @@
 name: xmrig
 category: cryptocurrency
-version: "6.12.2"
+version: "6.13.1"
 labels:
   github.repo: "xmrig"
   github.owner: "xmrig"


### PR DESCRIPTION
git stash drop: Hey! That stuff's expensive.