### PR TITLE
Bump cryptocurrency/xmrig to 6.14.0

### DIFF
--- a/amd64/packages/xmrig/definition.yaml
+++ b/amd64/packages/xmrig/definition.yaml
@@ -1,6 +1,6 @@
 name: xmrig
 category: cryptocurrency
-version: "6.13.1"
+version: "6.14.0"
 labels:
   github.repo: "xmrig"
   github.owner: "xmrig"


### PR DESCRIPTION
git-prune: not as tasty as git-cherry, but much better for you