### PR TITLE
Bump container/docker to 19.03.15

### DIFF
--- a/packages/docker/definition.yaml
+++ b/packages/docker/definition.yaml
@@ -1,6 +1,6 @@
 name: docker
 category: container
-version: "20.10.9"
+version: "19.03.15"
 labels:
   github.repo: "docker-ce"
   github.owner: "docker"


### PR DESCRIPTION
git: where we dropped our trunks and all have masters