### PR TITLE
Bump utils/goreleaser to 1.3.1

### DIFF
--- a/packages/goreleaser/definition.yaml
+++ b/packages/goreleaser/definition.yaml
@@ -1,6 +1,6 @@
 name: goreleaser
 category: utils
-version: "1.2.5"
+version: "1.3.1"
 description: "Deliver Go binaries as fast and easily as possible"
 labels:
   github.repo: "goreleaser"


### PR DESCRIPTION
git request-pull: only legal in Nevada.