### PR TITLE
Bump utils/packer to 1.7.9

### DIFF
--- a/packages/packer/definition.yaml
+++ b/packages/packer/definition.yaml
@@ -1,6 +1,6 @@
 category: "utils"
 name: "packer"
-version: "1.7.8"
+version: "1.7.10"
 license: "MPL-2.0"
 description: "Packer is a tool for creating identical machine images for multiple platforms from a single source configuration"
 labels:


### PR DESCRIPTION
Because she didn't get arrays