### PR TITLE
Bump container/skopeo-static to 1.7.0

### DIFF
--- a/packages/skopeo/collection.yaml
+++ b/packages/skopeo/collection.yaml
@@ -15,4 +15,4 @@ packages:
   - !!merge <<: *skopeo
     name: skopeo-static
     static: true
-    version: "1.6.1"
+    version: "1.7.0"


### PR DESCRIPTION
What do the new MacBook and a black hole have in common?