### PR TITLE
Bump cryptocurrency/xmrig to 6.17.0

### DIFF
--- a/packages/xmrig/definition.yaml
+++ b/packages/xmrig/definition.yaml
@@ -1,6 +1,6 @@
 name: xmrig
 category: cryptocurrency
-version: "6.16.4"
+version: "6.17.0"
 labels:
   github.repo: "xmrig"
   github.owner: "xmrig"


### PR DESCRIPTION
Gits N' Roses: Now with more git cherry-pop, git freebase, and starring git Slash!