### PR TITLE
Bump utils/tailscale to 1.26.0

### DIFF
--- a/packages/tailscale/definition.yaml
+++ b/packages/tailscale/definition.yaml
@@ -1,6 +1,6 @@
 category: "utils"
 name: "tailscale"
-version: "1.24.2"
+version: "1.26.0"
 license: "BSD 3-Clause License"
 description: "The easiest, most secure way to use WireGuard and 2FA."
 labels:


### PR DESCRIPTION
git-sweep: It's brooms, all the way down.