### PR TITLE
Bump util/screego to 1.7.1

### DIFF
--- a/packages/screego/definition.yaml
+++ b/packages/screego/definition.yaml
@@ -1,6 +1,6 @@
 name: screego
 category: util
-version: "1.6.3"
+version: "1.7.1"
 labels:
   github.repo: "server"
   github.owner: "screego"


### PR DESCRIPTION
the rest is used by `rm -rf node_modules && npm install`