### PR TITLE
Bump container/kubectl to 1.24.4

### DIFF
--- a/packages/kubectl/definition.yaml
+++ b/packages/kubectl/definition.yaml
@@ -1,6 +1,6 @@
 name: kubectl
 category: container
-version: "1.24.3"
+version: "1.25.2"
 labels:
   github.repo: "kubectl"
   github.owner: "kubernetes"
@@ -9,7 +9,7 @@ labels:
   autobump.prefix: "prefix"
   autobump.hook: "curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt | sed 's/v//'"
   autobump.version_hook: "curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt | sed 's/v//'"
-  package.version: "1.24.3"
+  package.version: "1.25.2"
 uri:
   - https://github.com/kubernetes/kubernetes
   - https://kubernetes.io


### PR DESCRIPTION
git: history is written by the committers.